### PR TITLE
Allow CORS origin for hambach/redwood branch deploys

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -20,6 +20,8 @@ import { pgPool } from 'common/pool';
 const REGEN_HOSTNAME_PATTERN = /regen\.network$/;
 const WEBSITE_PREVIEW_HOSTNAME_PATTERN = /deploy-preview-\d+--regen-website\.netlify\.app$/;
 const REGISTRY_PREVIEW_HOSTNAME_PATTERN = /deploy-preview-\d+--regen-registry\.netlify\.app$/;
+const REGISTRY_REDWOOD_HOSTNAME_PATTERN = /redwood--regen-registry\.netlify\.app$/;
+const REGISTRY_HAMBACH_HOSTNAME_PATTERN = /hambach--regen-registry\.netlify\.app$/;
 const AUTH0_HOSTNAME_PATTERN = /regen-network-registry\.auth0\.com$/;
 
 const corsOptions = (req, callback) => {
@@ -31,6 +33,8 @@ const corsOptions = (req, callback) => {
     if (originURL && (originURL.hostname.match(REGEN_HOSTNAME_PATTERN) ||
       originURL.hostname.match(WEBSITE_PREVIEW_HOSTNAME_PATTERN) ||
       originURL.hostname.match(REGISTRY_PREVIEW_HOSTNAME_PATTERN) ||
+      originURL.hostname.match(REGISTRY_REDWOOD_HOSTNAME_PATTERN) ||
+      originURL.hostname.match(REGISTRY_HAMBACH_HOSTNAME_PATTERN) ||
       originURL.hostname.match(AUTH0_HOSTNAME_PATTERN))) {
       options = { origin: true }; // reflect (enable) the requested origin in the CORS response
     } else {


### PR DESCRIPTION
## Description

ref: https://github.com/regen-network/regen-registry/issues/838

Needed so that the new testnet branch deploys (https://hambach--regen-registry.netlify.app/ and https://redwood--regen-registry.netlify.app/) can interact with the registry server.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all tests passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)