### PR TITLE
Fix "tsc not found" error in the heroku build process

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,9 @@
     "nodemailer": "^6.6.3",
     "postgraphile": "^4.7.0",
     "redis": "^3.1.1",
-    "stripe": "^8.120.0"
+    "stripe": "^8.120.0",
+    "ts-node": "^10.5.0",
+    "typescript": "^4.5.5"
   },
   "scripts": {
     "start": "ts-node Server.ts",


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/regen-registry/issues/882

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This adds ts-node and typescript back as dependencies in the `server/package.json`. Without these listed we get the failures documented in the issue above, when we do a build where `NODE_ENV=production`. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
