### PR TITLE
Flatten the metadata graph response

### DIFF
--- a/server/routes/metadata-graph.ts
+++ b/server/routes/metadata-graph.ts
@@ -23,7 +23,7 @@ router.get('/metadata-graph/:iri', async (req, res) => {
         if (!rows.length) {
           res.status(404).send(`metadata_graph with the iri ${iri} not found`);
         } else {
-          res.json(rows[0]);
+          res.json(rows[0].metadata);
         }
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/regen-registry/issues/890

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

- This adjusts the /metadata-graph endpoint
  to send just the metadata for a given IRI.
- Previously we had an extra key in the response.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
