### PR TITLE
kyle/897 api endpoints for gen iri

### DIFF
--- a/common.jest.config.js
+++ b/common.jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/__tests__/**/*.test.[jt]s'],
+};

--- a/common/.test-env
+++ b/common/.test-env
@@ -1,0 +1,1 @@
+TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/regen_registry

--- a/common/__tests__/metadata_graph.test.ts
+++ b/common/__tests__/metadata_graph.test.ts
@@ -6,6 +6,7 @@ describe('MetadataGraph', () => {
   const client = new Client({
     connectionString: dburl,
   });
+  const metadataGraph = new MetadataGraph(client);
 
   beforeAll(async () => {
     return await client.connect();
@@ -27,7 +28,7 @@ describe('MetadataGraph', () => {
         '@id': 'http://www.wikidata.org/wiki/Q102289/',
       },
     };
-    const { iri, metadata } = await MetadataGraph.insertDoc(client, doc);
+    const { iri, metadata } = await metadataGraph.insertDoc(doc);
     expect(iri).toBe(
       'regen:13toVhNei4y1Tt2Ebf2ZkCM1vQ3hcudK4miVKpaqgkc1mmaETcC3jjQ.rdf',
     );
@@ -40,8 +41,8 @@ describe('MetadataGraph', () => {
         '@id': 'http://www.wikidata.org/wiki/Q102289/',
       },
     };
-    const doc1 = await MetadataGraph.insertDoc(client, doc);
-    const doc2 = await MetadataGraph.insertDoc(client, doc);
+    const doc1 = await metadataGraph.insertDoc(doc);
+    const doc2 = await metadataGraph.insertDoc(doc);
     expect(doc1).toMatchObject(doc2);
   });
   test('fetch by iri is working..', async () => {
@@ -51,13 +52,13 @@ describe('MetadataGraph', () => {
         '@id': 'http://www.wikidata.org/wiki/Q102289/',
       },
     };
-    const { iri } = await MetadataGraph.insertDoc(client, doc);
-    const metadata = await MetadataGraph.fetchByIri(client, iri);
+    const { iri } = await metadataGraph.insertDoc(doc);
+    const metadata = await metadataGraph.fetchByIri(iri);
     expect(metadata).toMatchObject(doc);
   });
   test('fetch by iri throws an error when the iri is not found..', async () => {
     await expect(
-      MetadataGraph.fetchByIri(client, 'regen:abcdefgh.rdf'),
+      metadataGraph.fetchByIri('regen:abcdefgh.rdf'),
     ).rejects.toThrow();
   });
 });

--- a/common/__tests__/metadata_graph.test.ts
+++ b/common/__tests__/metadata_graph.test.ts
@@ -1,0 +1,47 @@
+import { Client } from 'pg';
+import { MetadataGraph } from '../metadata_graph';
+
+describe('MetadataGraph', () => {
+  const dburl = process.env.TEST_DATABASE_URL;
+  const client = new Client({
+    connectionString: dburl,
+  });
+
+  beforeAll(async () => {
+    return await client.connect();
+  });
+  beforeEach(async () => {
+    return await client.query('BEGIN');
+  });
+  afterEach(async () => {
+    return await client.query('ROLLBACK');
+  });
+  afterAll(async () => {
+    return await client.end();
+  });
+
+  test('inserts a doc', async () => {
+    const doc = {
+      'http://schema.org/name': 'Bucky Fuller',
+      'http://schema.org/url': {
+        '@id': 'http://www.wikidata.org/wiki/Q102289/',
+      },
+    };
+    const { iri, metadata } = await MetadataGraph.insert_doc(client, doc);
+    expect(iri).toBe(
+      'regen:13toVhNei4y1Tt2Ebf2ZkCM1vQ3hcudK4miVKpaqgkc1mmaETcC3jjQ.rdf',
+    );
+    expect(metadata).toMatchObject(doc);
+  });
+  test('inserting the same doc works idempotently', async () => {
+    const doc = {
+      'http://schema.org/name': 'Bucky Fuller',
+      'http://schema.org/url': {
+        '@id': 'http://www.wikidata.org/wiki/Q102289/',
+      },
+    };
+    const doc1 = await MetadataGraph.insert_doc(client, doc);
+    const doc2 = await MetadataGraph.insert_doc(client, doc);
+    expect(doc1).toMatchObject(doc2);
+  });
+});

--- a/common/__tests__/metadata_graph.test.ts
+++ b/common/__tests__/metadata_graph.test.ts
@@ -44,4 +44,20 @@ describe('MetadataGraph', () => {
     const doc2 = await MetadataGraph.insert_doc(client, doc);
     expect(doc1).toMatchObject(doc2);
   });
+  test('fetch by iri is working..', async () => {
+    const doc = {
+      'http://schema.org/name': 'Bucky Fuller',
+      'http://schema.org/url': {
+        '@id': 'http://www.wikidata.org/wiki/Q102289/',
+      },
+    };
+    const { iri } = await MetadataGraph.insert_doc(client, doc);
+    const metadata = await MetadataGraph.fetch_by_iri(client, iri);
+    expect(metadata).toMatchObject(doc);
+  });
+  test('fetch by iri throws an error when the iri is not found..', async () => {
+    await expect(
+      MetadataGraph.fetch_by_iri(client, 'regen:abcdefgh.rdf'),
+    ).rejects.toThrow();
+  });
 });

--- a/common/__tests__/metadata_graph.test.ts
+++ b/common/__tests__/metadata_graph.test.ts
@@ -27,7 +27,7 @@ describe('MetadataGraph', () => {
         '@id': 'http://www.wikidata.org/wiki/Q102289/',
       },
     };
-    const { iri, metadata } = await MetadataGraph.insert_doc(client, doc);
+    const { iri, metadata } = await MetadataGraph.insertDoc(client, doc);
     expect(iri).toBe(
       'regen:13toVhNei4y1Tt2Ebf2ZkCM1vQ3hcudK4miVKpaqgkc1mmaETcC3jjQ.rdf',
     );
@@ -40,8 +40,8 @@ describe('MetadataGraph', () => {
         '@id': 'http://www.wikidata.org/wiki/Q102289/',
       },
     };
-    const doc1 = await MetadataGraph.insert_doc(client, doc);
-    const doc2 = await MetadataGraph.insert_doc(client, doc);
+    const doc1 = await MetadataGraph.insertDoc(client, doc);
+    const doc2 = await MetadataGraph.insertDoc(client, doc);
     expect(doc1).toMatchObject(doc2);
   });
   test('fetch by iri is working..', async () => {
@@ -51,13 +51,13 @@ describe('MetadataGraph', () => {
         '@id': 'http://www.wikidata.org/wiki/Q102289/',
       },
     };
-    const { iri } = await MetadataGraph.insert_doc(client, doc);
-    const metadata = await MetadataGraph.fetch_by_iri(client, iri);
+    const { iri } = await MetadataGraph.insertDoc(client, doc);
+    const metadata = await MetadataGraph.fetchByIri(client, iri);
     expect(metadata).toMatchObject(doc);
   });
   test('fetch by iri throws an error when the iri is not found..', async () => {
     await expect(
-      MetadataGraph.fetch_by_iri(client, 'regen:abcdefgh.rdf'),
+      MetadataGraph.fetchByIri(client, 'regen:abcdefgh.rdf'),
     ).rejects.toThrow();
   });
 });

--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -1,4 +1,4 @@
-const commonConfig = require("../common.jest.config")
+const commonConfig = require('../common.jest.config'); // eslint-disable-line
 module.exports = {
   ...commonConfig,
   setupFiles: ['./jestSetupFile.ts'],

--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -1,6 +1,5 @@
+const commonConfig = require("../common.jest.config")
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['<rootDir>/**/__tests__/*.test.[jt]s'],
+  ...commonConfig,
   setupFiles: ['./jestSetupFile.ts'],
 };

--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/**/__tests__/*.test.[jt]s'],
+  setupFiles: ['./jestSetupFile.ts'],
+};

--- a/common/jestSetupFile.ts
+++ b/common/jestSetupFile.ts
@@ -1,0 +1,3 @@
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: './.test-env' });

--- a/common/metadata_graph.ts
+++ b/common/metadata_graph.ts
@@ -20,21 +20,21 @@ export const MetadataGraph = {
     );
     return resp.rows[0];
   },
-  insert_iri_doc: async function (
+  insertIriDoc: async function (
     client: PoolClient | Client,
     iri: string,
     metadata: JsonLdDocument,
   ) {
     return await this.insert(client, iri, metadata);
   },
-  insert_doc: async function (
+  insertDoc: async function (
     client: PoolClient | Client,
     metadata: JsonLdDocument,
   ) {
     const iri = await generateIRI(metadata);
     return await this.insert(client, iri, metadata);
   },
-  fetch_by_iri: async function (client: PoolClient | Client, iri: string) {
+  fetchByIri: async function (client: PoolClient | Client, iri: string) {
     const { rows } = await client.query(
       'SELECT metadata FROM metadata_graph WHERE iri=$1 LIMIT 1',
       [iri],

--- a/common/metadata_graph.ts
+++ b/common/metadata_graph.ts
@@ -2,6 +2,12 @@ import { JsonLdDocument } from 'jsonld';
 import { PoolClient, Client } from 'pg';
 import { generateIRI } from 'iri-gen/iri-gen';
 
+export class MetadataNotFound extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 export const MetadataGraph = {
   insert: async function (
     client: PoolClient | Client,
@@ -33,6 +39,11 @@ export const MetadataGraph = {
       'SELECT metadata FROM metadata_graph WHERE iri=$1 LIMIT 1',
       [iri],
     );
-    return rows;
+    if (rows.length === 0) {
+      throw new MetadataNotFound('Metadata not found');
+    } else {
+      const [row] = rows;
+      return row.metadata;
+    }
   },
 };

--- a/common/metadata_graph.ts
+++ b/common/metadata_graph.ts
@@ -11,7 +11,7 @@ export class MetadataNotFound extends Error {
 type MetadataGraphRow = {
   iri: string;
   metadata: JsonLdDocument;
-}
+};
 
 export class MetadataGraph {
   client: PoolClient | Client;
@@ -20,7 +20,10 @@ export class MetadataGraph {
     this.client = client;
   }
 
-  async insert(iri: string, metadata: JsonLdDocument): Promise<MetadataGraphRow> {
+  async insert(
+    iri: string,
+    metadata: JsonLdDocument,
+  ): Promise<MetadataGraphRow> {
     const resp = await this.client.query(
       'INSERT INTO metadata_graph (iri, metadata) VALUES ($1, $2) ON CONFLICT (iri) DO UPDATE SET iri=$1, metadata=$2 RETURNING iri, metadata',
       [iri, metadata],
@@ -28,7 +31,10 @@ export class MetadataGraph {
     return resp.rows[0];
   }
 
-  async insertIriDoc(iri: string, metadata: JsonLdDocument): Promise<MetadataGraphRow> {
+  async insertIriDoc(
+    iri: string,
+    metadata: JsonLdDocument,
+  ): Promise<MetadataGraphRow> {
     return await this.insert(iri, metadata);
   }
 

--- a/common/metadata_graph.ts
+++ b/common/metadata_graph.ts
@@ -1,0 +1,38 @@
+import { JsonLdDocument } from 'jsonld';
+import { PoolClient, Client } from 'pg';
+import { generateIRI } from 'iri-gen/iri-gen';
+
+export const MetadataGraph = {
+  insert: async function (
+    client: PoolClient | Client,
+    iri: string,
+    metadata: JsonLdDocument,
+  ) {
+    const resp = await client.query(
+      'INSERT INTO metadata_graph (iri, metadata) VALUES ($1, $2) ON CONFLICT (iri) DO UPDATE SET iri=$1, metadata=$2 RETURNING iri, metadata',
+      [iri, metadata],
+    );
+    return resp.rows[0];
+  },
+  insert_iri_doc: async function (
+    client: PoolClient | Client,
+    iri: string,
+    metadata: JsonLdDocument,
+  ) {
+    return await this.insert(client, iri, metadata);
+  },
+  insert_doc: async function (
+    client: PoolClient | Client,
+    metadata: JsonLdDocument,
+  ) {
+    const iri = await generateIRI(metadata);
+    return await this.insert(client, iri, metadata);
+  },
+  fetch_by_iri: async function (client: PoolClient | Client, iri: string) {
+    const { rows } = await client.query(
+      'SELECT metadata FROM metadata_graph WHERE iri=$1 LIMIT 1',
+      [iri],
+    );
+    return rows;
+  },
+};

--- a/common/package.json
+++ b/common/package.json
@@ -4,5 +4,8 @@
   "description": "Common module for shared code in registry-server",
   "repository": "https://github.com/regen-network/registry-server",
   "author": "wgwz",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "test": "jest"
+  }
 }

--- a/iri-gen/__tests__/iri-gen.test.ts
+++ b/iri-gen/__tests__/iri-gen.test.ts
@@ -33,4 +33,10 @@ describe('generateIRI', () => {
       'regen:13toVgutDdVPL4Q3s8hqgSSm7ZwfhiCtmXFpNn9vevxyLFFUT6HN1QD.rdf',
     );
   });
+  it('throws an error for an invalid JSON-LD document', async () => {
+    const doc = {
+      foo: 'bar',
+    };
+    await expect(generateIRI(doc)).rejects.toThrow('Invalid JSON-LD document');
+  });
 });

--- a/iri-gen/index.ts
+++ b/iri-gen/index.ts
@@ -32,7 +32,8 @@ async function main(): Promise<void> {
       console.log(`The IRI for ${path} is: ${iri}`);
       if (insertFlag) {
         console.log('Inserting IRI, and metadata into metadata_graph table.');
-        await MetadataGraph.insertIriDoc(client, iri, doc);
+        const metadataGraph = new MetadataGraph(client);
+        await metadataGraph.insertIriDoc(iri, doc);
         console.log('IRI and metadata inserted successfully.');
         process.exit(0);
       } else {

--- a/iri-gen/index.ts
+++ b/iri-gen/index.ts
@@ -25,12 +25,12 @@ async function main(): Promise<void> {
   const path = argv._[0];
   let client: PoolClient;
   try {
-    client = await pgPool.connect();
     const doc = await readDocument(path);
     const iri = await generateIRI(doc);
     if (iri) {
       console.log(`The IRI for ${path} is: ${iri}`);
       if (insertFlag) {
+        client = await pgPool.connect();
         console.log('Inserting IRI, and metadata into metadata_graph table.');
         const metadataGraph = new MetadataGraph(client);
         await metadataGraph.insertIriDoc(iri, doc);

--- a/iri-gen/index.ts
+++ b/iri-gen/index.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
       console.log(`The IRI for ${path} is: ${iri}`);
       if (insertFlag) {
         console.log('Inserting IRI, and metadata into metadata_graph table.');
-        await MetadataGraph.insert_iri_doc(client, iri, doc);
+        await MetadataGraph.insertIriDoc(client, iri, doc);
         console.log('IRI and metadata inserted successfully.');
         process.exit(0);
       } else {

--- a/iri-gen/iri-gen.ts
+++ b/iri-gen/iri-gen.ts
@@ -72,20 +72,18 @@ function checksum(input: Uint8Array): Uint8Array {
  * @returns Promise
  */
 export async function generateIRI(doc: jsonld.JsonLdDocument): Promise<string> {
-  try {
-    // Canonize JSON-LD to n-quads
-    const canonized = await jsonld.canonize(doc, {
-      algorithm: 'URDNA2015',
-      format: 'application/n-quads',
-    });
-
-    // Generate BLAKE2b with 256 bits (32 bytes) length hash
-    const hash = blake.blake2b(canonized, null, 32);
-
-    // Get IRI from hash
-    const iri = toIRI(hash);
-    return iri;
-  } catch (e) {
-    console.error(e);
+  // Canonize JSON-LD to n-quads
+  const canonized = await jsonld.canonize(doc, {
+    algorithm: 'URDNA2015',
+    format: 'application/n-quads',
+  });
+  if (canonized === '') {
+    throw new Error('Invalid JSON-LD document');
   }
+  // Generate BLAKE2b with 256 bits (32 bytes) length hash
+  const hash = blake.blake2b(canonized, null, 32);
+
+  // Get IRI from hash
+  const iri = toIRI(hash);
+  return iri;
 }

--- a/iri-gen/iri-gen.ts
+++ b/iri-gen/iri-gen.ts
@@ -65,6 +65,12 @@ function checksum(input: Uint8Array): Uint8Array {
   return h2.slice(0, 4);
 }
 
+export class InvalidJSONLD extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 /**
  * generateIRI canonizes a JSON-LD doc and generates a hash for it using BLAKE2b (256 bits)
  * then converts this hash into an IRI based on the pattern described in toIRI function
@@ -78,7 +84,7 @@ export async function generateIRI(doc: jsonld.JsonLdDocument): Promise<string> {
     format: 'application/n-quads',
   });
   if (canonized === '') {
-    throw new Error('Invalid JSON-LD document');
+    throw new InvalidJSONLD('Invalid JSON-LD document');
   }
   // Generate BLAKE2b with 256 bits (32 bytes) length hash
   const hash = blake.blake2b(canonized, null, 32);

--- a/iri-gen/jest.config.js
+++ b/iri-gen/jest.config.js
@@ -1,5 +1,4 @@
+const commonConfig = require("../common.jest.config")
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['<rootDir>/**/__tests__/*.test.[jt]s'],
+  ...commonConfig,
 };

--- a/iri-gen/jest.config.js
+++ b/iri-gen/jest.config.js
@@ -1,4 +1,4 @@
-const commonConfig = require("../common.jest.config")
+const commonConfig = require('../common.jest.config'); // eslint-disable-line
 module.exports = {
   ...commonConfig,
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postinstall": "lerna bootstrap",
     "serve": "lerna run --scope=registry-server start --stream",
     "dev": "(cd server && yarn watch) & yarn serve",
-    "test": "lerna run test",
+    "test": "lerna run --stream test -- --verbose",
     "migrate": "flyway -c flyway.js migrate",
     "dbinfo": "flyway -c flyway.js info",
     "build": "lerna run build",

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -62,6 +62,8 @@ app.use(cors(corsOptions));
 
 app.use(getJwt(false));
 
+app.use(express.json());
+
 app.use('/image', imageOptimizer());
 
 app.use(

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -130,6 +130,8 @@ import auth from './routes/auth';
 import recaptcha from './routes/recaptcha';
 import files from './routes/files';
 import metadataGraph from './routes/metadata-graph';
+import { MetadataNotFound } from 'common/metadata_graph';
+import { InvalidJSONLD } from 'iri-gen/iri-gen';
 app.use(mailerlite);
 app.use(contact);
 app.use(buyersInfo);
@@ -138,6 +140,23 @@ app.use(auth);
 app.use(recaptcha);
 app.use(files);
 app.use(metadataGraph);
+
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  const { params, query, body, path } = req;
+  console.error('req info:', { params, query, body, path });
+  next(err);
+});
+app.use((err, req, res, next) => {
+  const errResponse = { error: err.message };
+  if (err instanceof MetadataNotFound) {
+    res.status(404).send(errResponse);
+  } else if (err instanceof InvalidJSONLD) {
+    res.status(400).send(errResponse);
+  } else {
+    next(err);
+  }
+});
 
 const port = process.env.PORT || 5000;
 

--- a/server/__tests__/db/helpers.ts
+++ b/server/__tests__/db/helpers.ts
@@ -1,5 +1,5 @@
 import { Pool, PoolClient, QueryResult } from 'pg';
-import dotenv from 'dotenv';
+import * as dotenv from 'dotenv';
 dotenv.config();
 
 const pools = {};
@@ -56,8 +56,8 @@ const withDbFromUrl = async <T>(
     }
     throw e;
   } finally {
-    await client.query('ROLLBACK;');
-    await client.query('RESET ALL;'); // Shouldn't be necessary, but just in case...
+    await client.query('ROLLBACK');
+    await client.query('RESET ALL'); // Shouldn't be necessary, but just in case...
     await client.release();
   }
 };

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,5 +1,4 @@
+const commonConfig = require("../common.jest.config")
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['<rootDir>/**/__tests__/**/*.test.[jt]s'],
+  ...commonConfig,
 };

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,4 +1,4 @@
-const commonConfig = require("../common.jest.config")
+const commonConfig = require('../common.jest.config'); // eslint-disable-line
 module.exports = {
   ...commonConfig,
 };

--- a/server/routes/metadata-graph.ts
+++ b/server/routes/metadata-graph.ts
@@ -18,7 +18,8 @@ router.get('/metadata-graph/:iri', async (req, res, next) => {
   }
   try {
     client = await pgPool.connect();
-    const metadata = await MetadataGraph.fetchByIri(client, iri);
+    const metadataGraph = new MetadataGraph(client);
+    const metadata = await metadataGraph.fetchByIri(iri);
     return res.json(metadata);
   } catch (err) {
     next(err);
@@ -42,7 +43,8 @@ router.post('/iri-gen', async (req, res, next) => {
   let client: PoolClient;
   try {
     client = await pgPool.connect();
-    const resp = await MetadataGraph.insertDoc(client, req.body);
+    const metadataGraph = new MetadataGraph(client);
+    const resp = await metadataGraph.insertDoc(req.body);
     return res.status(201).json(resp);
   } catch (err) {
     next(err);

--- a/server/routes/metadata-graph.ts
+++ b/server/routes/metadata-graph.ts
@@ -18,7 +18,7 @@ router.get('/metadata-graph/:iri', async (req, res, next) => {
   }
   try {
     client = await pgPool.connect();
-    const metadata = await MetadataGraph.fetch_by_iri(client, iri);
+    const metadata = await MetadataGraph.fetchByIri(client, iri);
     return res.json(metadata);
   } catch (err) {
     next(err);
@@ -42,7 +42,7 @@ router.post('/iri-gen', async (req, res, next) => {
   let client: PoolClient;
   try {
     client = await pgPool.connect();
-    const resp = await MetadataGraph.insert_doc(client, req.body);
+    const resp = await MetadataGraph.insertDoc(client, req.body);
     return res.status(201).json(resp);
   } catch (err) {
     next(err);

--- a/server/routes/metadata-graph.ts
+++ b/server/routes/metadata-graph.ts
@@ -1,13 +1,16 @@
 import * as express from 'express';
+import { PoolClient } from 'pg';
 
 import { pgPool } from 'common/pool';
+import { MetadataGraph } from 'common/metadata_graph';
+import { generateIRI } from 'iri-gen/iri-gen';
 
 const router = express.Router();
 
 router.get('/metadata-graph/:iri', async (req, res) => {
   const { iri } = req.params;
   const iri_re = new RegExp('regen:.+.rdf');
-  let client;
+  let client: PoolClient;
   try {
     if (!iri_re.test(iri)) {
       res
@@ -23,7 +26,7 @@ router.get('/metadata-graph/:iri', async (req, res) => {
         if (!rows.length) {
           res.status(404).send(`metadata_graph with the iri ${iri} not found`);
         } else {
-          res.json(rows[0]);
+          res.json(rows[0].metadata);
         }
       } catch (err) {
         console.error(err);
@@ -32,6 +35,26 @@ router.get('/metadata-graph/:iri', async (req, res) => {
     }
   } catch (err) {
     console.error('Error acquiring postgres client', err);
+    res.sendStatus(500);
+  } finally {
+    if (client) {
+      client.release();
+    }
+  }
+});
+
+router.get('/iri-gen', async (req, res) => {
+  const iri = await generateIRI(req.body);
+  return res.json({ iri });
+});
+
+router.post('/iri-gen', async (req, res) => {
+  let client: PoolClient;
+  try {
+    client = await pgPool.connect();
+    const resp = await MetadataGraph.insert_doc(client, req.body);
+    return res.status(201).json(resp);
+  } catch (err) {
     res.sendStatus(500);
   } finally {
     if (client) {


### PR DESCRIPTION
Closes: https://github.com/regen-network/regen-registry/issues/897

Adds /iri-gen endpoint

- Adds a GET verb at /iri-gen. This endpoint expects
  a JSON body of "metadata". After generating the IRI
  it returns the IRI in a JSON object.
- Adds a POST verb at /iri-gen. This endpoint expects
  a JSON body of "metadata". After generating the IRI
  it idempotently adds the IRI and metadata to our
  database and returns the IRI and metadata in a JSON
  object.
- This also moves some code related to both the iri-gen
  and new endpoints into the common module.
- Notably, this adds tests for common module as well.
