### PR TITLE
Fix heroku nodejs engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^26.4.4"
   },
   "engines": {
-    "node": ">=10.15.3"
+    "node": "16.x"
   },
   "resolutions": {
     "pg-connection-string": "2.x"


### PR DESCRIPTION
## Description

The manual deployment to production failed with these messages:

```
➜  registry-server git:(master) ✗ git push regen-registry-server master:main                                                                                                                                   [30/53]
Enumerating objects: 3414, done.
Counting objects: 100% (3414/3414), done.
Delta compression using up to 8 threads
Compressing objects: 100% (1975/1975), done.
Writing objects: 100% (3414/3414), 15.32 MiB | 3.46 MiB/s, done.
Total 3414 (delta 2204), reused 2120 (delta 1336), pack-reused 0
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Building on the Heroku-18 stack
remote: -----> Using buildpack: heroku/nodejs
remote: -----> Node.js app detected
remote:
remote: -----> Creating runtime environment
remote:
remote:        NPM_CONFIG_LOGLEVEL=error
remote:        USE_YARN_CACHE=true
remote:        NODE_OPTIONS=--max_old_space_size=8192
remote:        NODE_ENV=production
remote:        NODE_MODULES_CACHE=true
remote:        NODE_VERBOSE=false
remote:
remote: -----> Installing binaries
remote:        engines.node (package.json):  >=10.15.3
remote:        engines.npm (package.json):   unspecified (use default)
remote:        engines.yarn (package.json):  unspecified (use default)                                                                                                                                          [4/53]
remote:
remote:        Resolving node version >=10.15.3...
remote:        Downloading and installing node 18.1.0...
remote: node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
remote:
remote: -----> Build failed
remote:
remote:        We're sorry this build is failing! You can troubleshoot common issues here:
remote:        https://devcenter.heroku.com/articles/troubleshooting-node-deploys
remote:
remote:        Some possible problems:
remote:
remote:        - Dangerous semver range (>) in engines.node
remote:          https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
remote:
remote:        Love,
remote:        Heroku
remote:
remote:  !     Push rejected, failed to compile Node.js app.
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !       Push rejected to regen-registry-server.
remote:
To https://git.heroku.com/regen-registry-server.git
 ! [remote rejected] master -> main (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/regen-registry-server.git'
```

After specifying [the LTS node version in the engines config section][1], the build suceeded. This PR is about that change.

[1]: https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
