### PR TITLE
Add postgraphile ConnectionFilterPlugin

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -3,17 +3,17 @@ import { postgraphile } from 'postgraphile';
 import fileUpload from 'express-fileupload';
 import cors from 'cors';
 import { createProxyMiddleware } from 'http-proxy-middleware';
-
-import { UserIncomingMessage } from './types';
-import getJwt from './middleware/jwt';
-import imageOptimizer from './middleware/imageOptimizer';
-
 // To get this many-to-many plugin import statement working, we
 // needed to add esModuleInterop to the tsconfig compiler settings.
 // Per this issue: https://github.com/graphile-contrib/pg-many-to-many/issues/64
 import PgManyToManyPlugin from '@graphile-contrib/pg-many-to-many';
+import ConnectionFilterPlugin from 'postgraphile-plugin-connection-filter';
 import url from 'url';
 import dotenv from 'dotenv';
+
+import { UserIncomingMessage } from './types';
+import getJwt from './middleware/jwt';
+import imageOptimizer from './middleware/imageOptimizer';
 
 if (process.env.NODE_ENV !== 'production') {
   dotenv.config();
@@ -107,7 +107,12 @@ app.use(
     graphiql: true,
     watchPg: true,
     dynamicJson: true,
-    appendPlugins: [PgManyToManyPlugin],
+    graphileBuildOptions: {
+      connectionFilterComputedColumns: false,
+      connectionFilterArrays: false,
+      connectionFilterSetofFunctions: false,
+    },
+    appendPlugins: [PgManyToManyPlugin, ConnectionFilterPlugin],
     pgSettings: (req: UserIncomingMessage) => {
       if (req.user && req.user.sub) {
         const { sub } = req.user;

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -108,6 +108,8 @@ app.use(
     watchPg: true,
     dynamicJson: true,
     graphileBuildOptions: {
+      connectionFilterAllowedFieldTypes: ['JSON'],
+      connectionFilterAllowedOperators: ['contains'],
       connectionFilterComputedColumns: false,
       connectionFilterArrays: false,
       connectionFilterSetofFunctions: false,

--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
     "mjml": "^4.8.1",
     "nodemailer": "^6.6.3",
     "postgraphile": "^4.7.0",
+    "postgraphile-plugin-connection-filter": "^2.3.0",
     "redis": "^3.1.1",
     "stripe": "^8.120.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8363,6 +8363,13 @@ postgraphile-core@4.12.2:
     graphile-build-pg "4.12.2"
     tslib "^2.0.1"
 
+postgraphile-plugin-connection-filter@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/postgraphile-plugin-connection-filter/-/postgraphile-plugin-connection-filter-2.3.0.tgz#0ef9316f73b3cac6452187debe2053c379cf2ade"
+  integrity sha512-TR5bq/NOqqtm4xV3D2Qw+CJo0Hanrx1lqh0KZiU78z8YijcLC0NuT3z0nJyCB842nWbx5Wi6p0S+xmrgzRFNgQ==
+  dependencies:
+    tslib "^2.3.0"
+
 postgraphile@^4.7.0:
   version "4.12.8"
   resolved "https://registry.npmjs.org/postgraphile/-/postgraphile-4.12.8.tgz"
@@ -10067,6 +10074,11 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Description

Ref: https://github.com/regen-network/regen-registry/issues/928

This adds the following postgraphile plugin: https://github.com/graphile-contrib/postgraphile-plugin-connection-filter so we can filter by certain jsonb fields value, eg filter projects by `regen:vcsProjectId` which is a field that is in the metadata of VCS projects. This can be used to map an on-chain credit batch (which also references some `regen:vcsProjectId` in its metadata) to an off-chain project (until we have on-chain projects).

Also see https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/issues/31

Front-end PR upcoming

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
