### PR TITLE
Use named volume for database during local dev

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -11,10 +11,13 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./.postgres:/var/lib/postgresql/data
+      - db:/var/lib/postgresql/data
       # - ./scripts:/docker-entrypoint-initdb.d
   redis:
     image: redis:latest
     restart: always
     ports:
       - "6379:6379"
+
+volumes:
+  db:


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This is a small change to docker-compose for local development. It switches docker to use named volume for storing the postgres data/config during local development.

Previously the volume was being stored under `server/.postgres`. This was handy in the case where you need to delete the folder (fresh clean database). But the same can be achieved by working with the `docker volume` command. One reason I'm proposing the change is because I saw some weird permissions errors related to this folder during my local development (I think using named volume could help avoid that).

TODO:
- [ ] add some docs for various docker volume commands that we might need

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
