### PR TITLE
fix: only handle uncaught exceptions with sentry

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -223,9 +223,6 @@ app.use(
   }),
 );
 
-// The error handler must be before any other error middleware and after all controllers
-app.use(Sentry.Handlers.errorHandler());
-
 app.use((err, req, res, next) => {
   console.error(err.stack);
   const { params, query, body, path } = req;
@@ -242,6 +239,11 @@ app.use((err, req, res, next) => {
     next(err);
   }
 });
+
+// this is the last error handler to register we only want the
+// uncaught exceptions to be sent to sentry. otherwise we end
+// up with a lot of noise in sentry.
+app.use(Sentry.Handlers.errorHandler());
 
 const port = process.env.PORT || 5000;
 


### PR DESCRIPTION
## Description

fix: only handle uncaught exceptions with sentry

This results in less noise in sentry. It's a significant problem for us since it's causing us to use nearly all of our monthly capacity in sentry. This is mostly an oversight on my part during set up.

A further improvement we can do later is to prevent the local development environment from sending sentry errors. BUT right now, I don't think it's necessary, because the amount of garbage events we were sending prior to this change was much much greater. 

TL;DR 74k transactions were used for metadata not found errors (our limit per month is 80k 😬 )

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
