### PR TITLE
feat: add flag to toggle sentry init and use

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -38,3 +38,6 @@ EXP_LEDGER_REST_ENDPOINT=
 # Once hambach/redwood/mainnet have upgraded to v4.0, we can get rid of this
 V4_LEDGER_TENDERMINT_RPC=http://194.37.81.19:26657/
 V4_LEDGER_REST_ENDPOINT=http://194.37.81.19:1317/
+# Sentry environment variables..
+SENTRY_ENVIRONMENT=
+SENTRY_ENABLED=

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -63,26 +63,31 @@ const corsOptions = (req, callback): void => {
 
 const app = express();
 
-Sentry.init({
-  dsn: 'https://92594830df5944ae87656e33c98f36fc@o1377530.ingest.sentry.io/6688455',
-  integrations: [
-    // enable HTTP calls tracing
-    new Sentry.Integrations.Http({ tracing: true }),
-    // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({ app }),
-  ],
-
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-  environment: process.env.SENTRY_ENVIRONMENT || 'development',
-});
-// RequestHandler creates a separate execution context using domains, so that every
-// transaction/span/breadcrumb is attached to its own Hub instance
-app.use(Sentry.Handlers.requestHandler());
-// TracingHandler creates a trace for every incoming request
-app.use(Sentry.Handlers.tracingHandler());
+// this flag is used to enable sentry
+// we only want this set in the production environment
+// without this set we will use too much of our sentry quota
+// it can also be used in local dev when testing sentry
+if (process.env.SENTRY_ENABLED) {
+  Sentry.init({
+    dsn: 'https://92594830df5944ae87656e33c98f36fc@o1377530.ingest.sentry.io/6688455',
+    integrations: [
+      // enable HTTP calls tracing
+      new Sentry.Integrations.Http({ tracing: true }),
+      // enable Express.js middleware tracing
+      new Tracing.Integrations.Express({ app }),
+    ],
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    tracesSampleRate: 1.0,
+    environment: process.env.SENTRY_ENVIRONMENT || 'development',
+  });
+  // RequestHandler creates a separate execution context using domains, so that every
+  // transaction/span/breadcrumb is attached to its own Hub instance
+  app.use(Sentry.Handlers.requestHandler());
+  // TracingHandler creates a trace for every incoming request
+  app.use(Sentry.Handlers.tracingHandler());
+}
 
 app.use(fileUpload());
 app.use(cors(corsOptions));


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/regen-registry/issues/1340

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR sets an environment variable to control which environments sentry will be used in. We will set this variable only in the production heroku environment. So this means Sentry will only be used in production.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
