### PR TITLE
fix: use ssl for postgres image caching in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Based on `server/.env.example`, create some `server/.env` file with appropriate 
 2. Start a development server with `yarn dev`. This runs in parallel the node `server` and watches/builds code in the `worker` (used for sending emails at the moment).
 3. Start coding!!
 
+### Alternative method for starting server
+
+This method is useful if you don't want to run the watch process.
+The tradeoff is that you must manually restart the command after making code changes.
+The example below shows how to increase the log verbosity for certain parts of the app.
+
+```
+$ cd registry-server
+$ DEBUG='express:*,express-sharp*' yarn start
+```
+
 ## Database
 
 ### Configuring postgres logging

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "common"
   ],
   "dependencies": {
+    "@keyv/postgres": "^1.4.1",
     "@lerna/project": "^3.21.0",
     "dotenv": "^16.0.0",
     "lerna": "^4.0.0",

--- a/server/middleware/imageOptimizer.ts
+++ b/server/middleware/imageOptimizer.ts
@@ -33,10 +33,11 @@ export default function imageOptimizer(): express.Router {
       console.log(
         "the cache info will be stored in the 'utilities.keyv' table",
       );
-      // the production postgres database requires a ca certificate in order to
-      // connect to it. whereas the staging database does not require
-      // verify-ca. arguably, we might want to impose the same restriction in
-      // the staging env for parity and less surprise.
+      // the staging and production postgres database requires an SSL connection.
+      // therefore we must include ssl options to the Keyv constructor.
+      //
+      // you can view our database configurations in the parameter group for our databases in AWS RDS.
+      // i.e. you will be able to see client SSL settings that we are using.
       //
       // more info available here:
       // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html

--- a/server/middleware/imageOptimizer.ts
+++ b/server/middleware/imageOptimizer.ts
@@ -7,14 +7,14 @@ import Redis from 'ioredis';
 import KeyvBrotli from '@keyv/compress-brotli';
 
 class InvalidRedisURLError extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = 'InvalidRedisURLError';
   }
 }
 
 class InvalidCacheBackendError extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = 'InvalidCacheBackendError';
   }

--- a/sql/V2_16__add_utility_schema.sql
+++ b/sql/V2_16__add_utility_schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS utilities;

--- a/sql/V2_17__drop_keyv_table_from_public_schema.sql
+++ b/sql/V2_17__drop_keyv_table_from_public_schema.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.keyv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,13 @@
   dependencies:
     pg "8.8.0"
 
+"@keyv/postgres@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@keyv/postgres/-/postgres-1.4.1.tgz#f100a8b3c83adf01f04b4a04df45661d225433ef"
+  integrity sha512-aMfMqm+Sl96V/praFWtYl3KNexgs9lWNcJUNm464U9PShXdUVY4smidNlnl+I4l6Kr9jetIeX0AQJa7kiCKp7w==
+  dependencies:
+    pg "8.8.0"
+
 "@keyv/redis@^2.1.2":
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/@keyv/redis/-/redis-2.3.6.tgz#462991af60b5b35af4e9ac8d05ad99a08ae2cfc2"


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1311

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Recently we added support for postgres as a backend to the image caching layer (primarily used for storing `express-sharp` image resizing results). Previously we were using redis as the caching backend for this.

Mysteriously, using postgres as a backend worked in staging but it did not work in production. It turned out to be an SSL connection issue and the `@keyv/postgres` package recently added SSL support.

This PR upgrades that package to the new version, and it adjusts our code to make use of the SSL certificate when connecting to both the staging and production database. It's quite similar to what we do in `pool.ts`.

Note:
- Post-merge to production, set `IMAGE_CACHING_BACKEND=postgres`.
- Check logs to make sure there are no errors
- Test queries like so: `http "http://localhost:5000/image/projects/mai-ndombe/image-3.jpg?quality=100&width=368"`

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
