### PR TITLE
fix: some imports need to be after dotenv for local dev

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -28,6 +28,14 @@ import { BaseHTTPError } from './errors';
 
 import { pgPool } from 'common/pool';
 
+if (process.env.NODE_ENV !== 'production') {
+  dotenv.config();
+}
+
+/* eslint-disable import/first */
+// we disable this lint rule for these import statements
+// w/o this the application does not start locally
+// these imports require env vars which are available only after dotenv.config is called
 import mailerlite from './routes/mailerlite';
 import contact from './routes/contact';
 import buyersInfo from './routes/buyers-info';
@@ -42,10 +50,8 @@ import { web3auth } from './routes/web3auth';
 import { csrfRouter } from './routes/csrf';
 
 import { invalidCsrfTokenError } from './middleware/csrf';
+/* eslint-enable import/first */
 
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config();
-}
 const REGEN_HOSTNAME_PATTERN = /regen\.network$/;
 const WEBSITE_PREVIEW_HOSTNAME_PATTERN =
   /deploy-preview-\d+--regen-website\.netlify\.app$/;


### PR DESCRIPTION
## Description

This is a fix for a bug I introduced while setting up [this lint rule](https://github.com/regen-network/registry-server/pull/269#discussion_r1091108336).
Some of our modules depend on having environment variables set prior to importing.
Therefore, in local development, `dotenv.config` must be called before we import these modules.
This is the easiest fix, I don't think it's worth a further refactor right now to avoid this problem.
It's a problem that can be better solved at a later time, but certainly not a critical one.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
