### PR TITLE
feat: add new policies for projects

### DIFF
--- a/server/__tests__/db/project.delete.policy.test.ts
+++ b/server/__tests__/db/project.delete.policy.test.ts
@@ -11,7 +11,7 @@ describe('the DELETE RLS policy for the project table...', () => {
       );
       const [{ wallet_id }] = addrsQ.rows;
       const insQuery = await client.query(
-        'INSERT INTO project (admin_id) VALUES ($1)',
+        'INSERT INTO project (admin_wallet_id) VALUES ($1)',
         [wallet_id],
       );
       expect(insQuery.rowCount).toBe(1);

--- a/server/__tests__/db/project.delete.policy.test.ts
+++ b/server/__tests__/db/project.delete.policy.test.ts
@@ -1,0 +1,22 @@
+import { PoolClient } from 'pg';
+import { withAuthUserDb } from './helpers';
+
+describe('the DELETE RLS policy for the project table...', () => {
+  it('should NOT allow a user to delete projects...', async () => {
+    const walletAddr = `regen${Math.random().toString().slice(2, 11)}`;
+    await withAuthUserDb(walletAddr, async (client: PoolClient) => {
+      const addrsQ = await client.query(
+        'select wallet_id from get_current_addrs() where addr=$1',
+        [walletAddr],
+      );
+      const [{ wallet_id }] = addrsQ.rows;
+      const insQuery = await client.query(
+        'INSERT INTO project (admin_id) VALUES ($1)',
+        [wallet_id],
+      );
+      expect(insQuery.rowCount).toBe(1);
+      const delQ = await client.query('DELETE FROM project');
+      expect(delQ.rowCount).toBe(0);
+    });
+  });
+});

--- a/server/__tests__/db/project.insert.policy.test.ts
+++ b/server/__tests__/db/project.insert.policy.test.ts
@@ -16,7 +16,7 @@ describe('the INSERT RLS policy for the project table...', () => {
       );
       const [{ wallet_id }] = addrsQ.rows;
       const insQuery = await client.query(
-        'INSERT INTO project (admin_id) VALUES ($1)',
+        'INSERT INTO project (admin_wallet_id) VALUES ($1)',
         [wallet_id],
       );
       expect(insQuery.rowCount).toBe(1);
@@ -38,10 +38,12 @@ describe('the INSERT RLS policy for the project table...', () => {
       const [{ wallet_id }] = addrsQ.rows;
       // switch the second user
       await becomeAuthUser(client, walletAddr2, accountId2);
-      // try to insert the first users wallet_id as admin_id
+      // try to insert the first users wallet_id as admin_wallet_id
       // this operation should fail
       await expect(
-        client.query('INSERT INTO project (admin_id) VALUES ($1)', [wallet_id]),
+        client.query('INSERT INTO project (admin_wallet_id) VALUES ($1)', [
+          wallet_id,
+        ]),
       ).rejects.toThrow(
         'new row violates row-level security policy for table "project"',
       );

--- a/server/__tests__/db/project.insert.policy.test.ts
+++ b/server/__tests__/db/project.insert.policy.test.ts
@@ -1,0 +1,50 @@
+import { PoolClient } from 'pg';
+import {
+  becomeAuthUser,
+  createAccount,
+  withAuthUserDb,
+  withRootDb,
+} from './helpers';
+
+describe('the INSERT RLS policy for the project table...', () => {
+  it('should allow a user to create a project with their own wallet as admin...', async () => {
+    const walletAddr = `regen${Math.random().toString().slice(2, 11)}`;
+    await withAuthUserDb(walletAddr, async (client: PoolClient) => {
+      const addrsQ = await client.query(
+        'select wallet_id from get_current_addrs() where addr=$1',
+        [walletAddr],
+      );
+      const [{ wallet_id }] = addrsQ.rows;
+      const insQuery = await client.query(
+        'INSERT INTO project (admin_id) VALUES ($1)',
+        [wallet_id],
+      );
+      expect(insQuery.rowCount).toBe(1);
+    });
+  });
+
+  it('should NOT allow a user to create a project with another users wallet as admin...', async () => {
+    const walletAddr = `regen${Math.random().toString().slice(2, 11)}`;
+    const walletAddr2 = `regen${Math.random().toString().slice(2, 11)}`;
+    await withRootDb(async (client: PoolClient) => {
+      const accountId = await createAccount(client, walletAddr);
+      const accountId2 = await createAccount(client, walletAddr2);
+      // get the wallet_id for the first user
+      await becomeAuthUser(client, walletAddr, accountId);
+      const addrsQ = await client.query(
+        'select wallet_id from get_current_addrs() where addr=$1',
+        [walletAddr],
+      );
+      const [{ wallet_id }] = addrsQ.rows;
+      // switch the second user
+      await becomeAuthUser(client, walletAddr2, accountId2);
+      // try to insert the first users wallet_id as admin_id
+      // this operation should fail
+      await expect(
+        client.query('INSERT INTO project (admin_id) VALUES ($1)', [wallet_id]),
+      ).rejects.toThrow(
+        'new row violates row-level security policy for table "project"',
+      );
+    });
+  });
+});

--- a/server/__tests__/db/project.update.policy.test.ts
+++ b/server/__tests__/db/project.update.policy.test.ts
@@ -1,0 +1,64 @@
+import { PoolClient } from 'pg';
+import {
+  becomeAuthUser,
+  createAccount,
+  withAuthUserDb,
+  withRootDb,
+} from './helpers';
+
+describe('the UPDATE RLS policy for the project table...', () => {
+  it('should allow a user to update a project they are admin for...', async () => {
+    const walletAddr = `regen${Math.random().toString().slice(2, 11)}`;
+    await withAuthUserDb(walletAddr, async (client: PoolClient) => {
+      const addrsQ = await client.query(
+        'select wallet_id from get_current_addrs() where addr=$1',
+        [walletAddr],
+      );
+      const [{ wallet_id }] = addrsQ.rows;
+      const insQuery = await client.query(
+        'INSERT INTO project (admin_id) VALUES ($1) RETURNING id AS project_id',
+        [wallet_id],
+      );
+      const [{ project_id }] = insQuery.rows;
+      const updQuery = await client.query(
+        'UPDATE project SET metadata = $2 WHERE id=$1',
+        [project_id, { foo: 'bar' }],
+      );
+      expect(updQuery.rowCount).toBe(1);
+    });
+  });
+
+  it('should NOT allow a user to update another users project...', async () => {
+    const walletAddr = `regen${Math.random().toString().slice(2, 11)}`;
+    const walletAddr2 = `regen${Math.random().toString().slice(2, 11)}`;
+    await withRootDb(async (client: PoolClient) => {
+      const accountId = await createAccount(client, walletAddr);
+      const accountId2 = await createAccount(client, walletAddr2);
+      // become the first user...
+      await becomeAuthUser(client, walletAddr, accountId);
+      const addrsQ = await client.query(
+        'select wallet_id from get_current_addrs() where addr=$1',
+        [walletAddr],
+      );
+      // get the wallet_id for the first user...
+      const [{ wallet_id }] = addrsQ.rows;
+      const insQuery = await client.query(
+        'INSERT INTO project (admin_id) VALUES ($1) RETURNING id AS project_id',
+        [wallet_id],
+      );
+      const [{ project_id }] = insQuery.rows;
+      // become the second user...
+      await becomeAuthUser(client, walletAddr2, accountId2);
+      // try to update the first users project...
+      // and expect an error...
+      await expect(
+        client.query('UPDATE project SET metadata = $2 WHERE id=$1', [
+          project_id,
+          { foo: 'bar' },
+        ]),
+      ).rejects.toThrow(
+        'new row violates row-level security policy for table "project"',
+      );
+    });
+  });
+});

--- a/server/__tests__/db/project.update.policy.test.ts
+++ b/server/__tests__/db/project.update.policy.test.ts
@@ -16,7 +16,7 @@ describe('the UPDATE RLS policy for the project table...', () => {
       );
       const [{ wallet_id }] = addrsQ.rows;
       const insQuery = await client.query(
-        'INSERT INTO project (admin_id) VALUES ($1) RETURNING id AS project_id',
+        'INSERT INTO project (admin_wallet_id) VALUES ($1) RETURNING id AS project_id',
         [wallet_id],
       );
       const [{ project_id }] = insQuery.rows;
@@ -43,7 +43,7 @@ describe('the UPDATE RLS policy for the project table...', () => {
       // get the wallet_id for the first user...
       const [{ wallet_id }] = addrsQ.rows;
       const insQuery = await client.query(
-        'INSERT INTO project (admin_id) VALUES ($1) RETURNING id AS project_id',
+        'INSERT INTO project (admin_wallet_id) VALUES ($1) RETURNING id AS project_id',
         [wallet_id],
       );
       const [{ project_id }] = insQuery.rows;

--- a/server/__tests__/db/project.update.policy.test.ts
+++ b/server/__tests__/db/project.update.policy.test.ts
@@ -50,15 +50,12 @@ describe('the UPDATE RLS policy for the project table...', () => {
       // become the second user...
       await becomeAuthUser(client, walletAddr2, accountId2);
       // try to update the first users project...
-      // and expect an error...
-      await expect(
-        client.query('UPDATE project SET metadata = $2 WHERE id=$1', [
-          project_id,
-          { foo: 'bar' },
-        ]),
-      ).rejects.toThrow(
-        'new row violates row-level security policy for table "project"',
+      const updQuery = await client.query(
+        'UPDATE project SET metadata = $2 WHERE id=$1',
+        [project_id, { foo: 'bar' }],
       );
+      // expect that no rows are modified...
+      expect(updQuery.rowCount).toBe(0);
     });
   });
 });

--- a/sql/V2_22__update_project_policies.sql
+++ b/sql/V2_22__update_project_policies.sql
@@ -75,10 +75,10 @@ CREATE POLICY project_insert_policy ON project
 DROP POLICY IF EXISTS project_update_policy ON project;
 CREATE POLICY project_update_policy ON project
     FOR UPDATE TO auth_user
-        USING (true)
-        WITH CHECK (admin_wallet_id in (
+        USING (admin_wallet_id in (
             SELECT
                 wallet_id
             FROM
                 get_current_addrs()
-        ));
+        ))
+        WITH CHECK (true);

--- a/sql/V2_22__update_project_policies.sql
+++ b/sql/V2_22__update_project_policies.sql
@@ -1,0 +1,77 @@
+ALTER TABLE project DROP COLUMN IF EXISTS creator_id CASCADE;
+
+DO $$
+BEGIN
+    ALTER TABLE project
+        ADD COLUMN admin_id uuid;
+EXCEPTION
+    WHEN duplicate_column THEN
+        RAISE NOTICE 'Field already exists. Ignoring...';
+END$$;
+
+DO $$
+BEGIN
+    ALTER TABLE project
+        ADD CONSTRAINT project_admin_id_fkey FOREIGN KEY (admin_id) REFERENCES wallet (id);
+EXCEPTION
+    WHEN duplicate_object THEN
+        RAISE NOTICE 'Constraint already exists. Ignoring...';
+END$$;
+
+DROP POLICY IF EXISTS project_app_user_create ON project;
+DROP POLICY IF EXISTS project_insert_admin ON project;
+DROP POLICY IF EXISTS project_delete_admin ON project;
+DROP POLICY IF EXISTS project_app_user_update ON project;
+
+-- NOTE: since this versioned migration depends on get_current_addrs and flyway
+-- runs versioned prior to the repeatable migration that defines
+-- get_current_addrs, we must specify a definition for this function in this
+-- migration.
+--
+-- if you need to make changes to get_current_addrs, do not
+-- change it here.  modify it in the repeatable migration file instead,
+-- R__get_current_addrs.sql.
+CREATE OR REPLACE FUNCTION get_current_addrs ()
+    RETURNS TABLE (
+        wallet_id uuid,
+        addr text,
+        profile_type party_type
+    )
+    AS $$ 
+DECLARE
+    v_account_id uuid;
+BEGIN
+    SELECT * INTO v_account_id FROM get_current_account();
+    RETURN query
+    SELECT
+        wallet.id, wallet.addr, party.type
+    FROM
+        account
+        JOIN party ON party.account_id = account.id
+        JOIN wallet ON party.wallet_id = wallet.id
+    WHERE
+        account.id = v_account_id;
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
+DROP POLICY IF EXISTS project_insert_policy ON project;
+CREATE POLICY project_insert_policy ON project
+    FOR INSERT TO auth_user
+        WITH CHECK (admin_id in (
+            SELECT
+                wallet_id
+            FROM
+                get_current_addrs()
+        ));
+
+DROP POLICY IF EXISTS project_update_policy ON project;
+CREATE POLICY project_update_policy ON project
+    FOR UPDATE TO auth_user
+        USING (true)
+        WITH CHECK (admin_id in (
+            SELECT
+                wallet_id
+            FROM
+                get_current_addrs()
+        ));

--- a/sql/V2_22__update_project_policies.sql
+++ b/sql/V2_22__update_project_policies.sql
@@ -30,21 +30,14 @@ DROP POLICY IF EXISTS project_insert_admin ON project;
 DROP POLICY IF EXISTS project_delete_admin ON project;
 DROP POLICY IF EXISTS project_app_user_update ON project;
 
--- NOTE: since this versioned migration depends on get_current_addrs and flyway
--- runs versioned prior to the repeatable migration that defines
--- get_current_addrs, we must specify a definition for this function in this
--- migration.
---
--- if you need to make changes to get_current_addrs, do not
--- change it here.  modify it in the repeatable migration file instead,
--- R__get_current_addrs.sql.
+DROP FUNCTION IF EXISTS get_current_addrs();
 CREATE OR REPLACE FUNCTION get_current_addrs ()
     RETURNS TABLE (
         wallet_id uuid,
         addr text,
         profile_type party_type
     )
-    AS $$ 
+    AS $$
 DECLARE
     v_account_id uuid;
 BEGIN

--- a/sql/V2_22__update_project_policies.sql
+++ b/sql/V2_22__update_project_policies.sql
@@ -18,6 +18,8 @@ EXCEPTION
         RAISE NOTICE 'Constraint already exists. Ignoring...';
 END$$;
 
+CREATE INDEX IF NOT EXISTS project_admin_wallet_id_idx ON project (admin_wallet_id);
+
 -- Deprecate the wallet_id column in favor of the new admin_wallet_id column
 -- Before removing the column, copy any existing data from the existing wallet_id column:
 UPDATE project SET admin_wallet_id = wallet_id;

--- a/sql/authn/R__get_current_addrs.sql
+++ b/sql/authn/R__get_current_addrs.sql
@@ -1,4 +1,3 @@
-DROP FUNCTION IF EXISTS get_current_addrs;
 CREATE OR REPLACE FUNCTION get_current_addrs ()
     RETURNS TABLE (
         wallet_id uuid,

--- a/sql/authn/R__get_current_addrs.sql
+++ b/sql/authn/R__get_current_addrs.sql
@@ -1,6 +1,7 @@
 DROP FUNCTION IF EXISTS get_current_addrs;
 CREATE OR REPLACE FUNCTION get_current_addrs ()
     RETURNS TABLE (
+        wallet_id uuid,
         addr text,
         profile_type party_type
     )
@@ -11,7 +12,7 @@ BEGIN
     SELECT * INTO v_account_id FROM get_current_account();
     RETURN query
     SELECT
-        wallet.addr, party.type
+        wallet.id, wallet.addr, party.type
     FROM
         account
         JOIN party ON party.account_id = account.id


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/regen-registry/issues/1552

Currently, this PR adds policies to the project table which introduces the rules below.
An authenticated user (the `auth_user` role):

1. can only create new project if they specify the admin as one of the addresses which belongs to their account.
2. is not allowed to delete any project, even there own.
    (i wasn't sure what the rule should be for delete so i went with a safe rule)
3. can only update any projects that they are an admin for.
    can only update the admin of a project to an address which belongs to their account.

Additionally, any user (the `app_user` role) can select all projects.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
