### PR TITLE
fix: add trust proxy setting

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -95,6 +95,8 @@ const corsOptions = (req, callback): void => {
 
 const app = express();
 
+app.set('trust proxy', true);
+
 // this flag is used to enable sentry
 // we only want this set in the production environment
 // without this set we will use too much of our sentry quota


### PR DESCRIPTION
## Description

Fixes: issue where cookie was not being set for deploy previews and the dev environment due to the fact that heroku uses a reverse proxy.

Issue was uncovered in this related PR:
https://github.com/regen-network/regen-web/pull/1819

the [docs for "cookieSession"][1] in the server say this:
> be sure to read how to [setup Express behind proxies][2] or the cookie may not ever set correctly.

this amounts to use adding this in our code:
```javascript
app.set('trust proxy', true);
```

I tested that even with this our local environment is still working.

Note:
- It may be possible to choose a more restrictive value here, but I think this is OK.
   I don't see a huge security concern, since we have CSRF protection.

[1]: http://expressjs.com/en/resources/middleware/cookie-session.html
[2]: https://expressjs.com/en/guide/behind-proxies.html

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
