### PR TITLE
fix: apt get docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16-bullseye 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get upgrade -y
 WORKDIR /app
 COPY yarn.lock .
 COPY package.json .


### PR DESCRIPTION
Docker composes was failing because it was prompting to do an upgrade.
This adds a flag to automatically accept upgrades.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
