### PR TITLE
feat: add graphiql instance that uses csrf-csrf (#318)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # dependencies
 node_modules
+.yarn
+.yarnrc
 
 # testing
 /coverage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap",
-    "serve": "lerna run --scope=registry-server start --stream",
+    "serve": "lerna run --scope=server start --stream",
     "dev": "(cd server && yarn build) && yarn serve & (cd server && yarn watch)",
     "test": "lerna run --stream test -- --verbose",
     "migrate": "flyway -c flyway.js migrate",

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -48,6 +48,7 @@ import { MetadataNotFound } from 'common/metadata_graph';
 import { InvalidJSONLD } from 'iri-gen/iri-gen';
 import { web3auth } from './routes/web3auth';
 import { csrfRouter } from './routes/csrf';
+import { graphiqlRouter } from './routes/graphiql';
 
 import { doubleCsrfProtection, invalidCsrfTokenError } from './middleware/csrf';
 import { sameSiteFromEnv } from './utils';
@@ -181,12 +182,9 @@ if (process.env.LEDGER_REST_ENDPOINT) {
   );
 }
 
-if (!process.env.GRAPHIQL_ENABLED) {
-  app.use('/graphql', doubleCsrfProtection);
-}
+app.use('/graphql', doubleCsrfProtection);
 app.use(
   postgraphile(pgPool, 'public', {
-    graphiql: process.env.GRAPHIQL_ENABLED ? true : false,
     watchPg: true,
     dynamicJson: true,
     graphileBuildOptions: {
@@ -229,6 +227,7 @@ app.use(files);
 app.use(metadataGraph);
 app.use('/web3auth', web3auth);
 app.use(csrfRouter);
+app.use('/graphiql', graphiqlRouter);
 
 const swaggerOptions = {
   definition: {
@@ -291,6 +290,4 @@ const port = process.env.PORT || 5000;
 app.listen(port);
 
 console.log('Started server on port ' + port);
-if (process.env.GRAPHIQL_ENABLED) {
-  console.log('Graphiql UI at http://localhost:' + port + '/graphiql');
-}
+console.log('Graphiql UI at http://localhost:' + port + '/graphiql');

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "registry-server",
+  "name": "server",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/server/routes/graphiql.ts
+++ b/server/routes/graphiql.ts
@@ -1,0 +1,9 @@
+import * as express from 'express';
+import path from 'path';
+
+export const graphiqlRouter = express.Router();
+
+graphiqlRouter.get('/', (req, res) => {
+  // https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn
+  res.sendFile(path.join(__dirname, '../views/graphiql.html'));
+});

--- a/server/views/graphiql.html
+++ b/server/views/graphiql.html
@@ -1,0 +1,91 @@
+<!--
+ *  Copyright (c) 2021 GraphQL Contributors
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GraphiQL</title>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bundler.
+    -->
+    <script
+      src="https://unpkg.com/react@17/umd/react.development.js"
+      integrity="sha512-Vf2xGDzpqUOEIKO+X2rgTLWPY+65++WPwCHkX2nFMu9IcstumPsf/uKKRd5prX3wOu8Q0GBylRpsDB26R6ExOg=="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+      integrity="sha512-Wr9OKCTtq1anK0hq5bY3X/AvDI5EflDSAh0mE9gma+4hl+kXdTJPKZ3TwLMBcrgUeoY0s3dq9JjhCQc7vddtFg=="
+      crossorigin="anonymous"
+    ></script>
+
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      const createSimpleFetcher =
+        options => async (graphQLParams, fetcherOpts) => {
+          const csrfResp = await window.fetch('/csrfToken', {
+            method: 'GET',
+            credentials: 'include',
+          });
+          const { token } = await csrfResp.json();
+          const data = await window.fetch(options.url, {
+            method: 'POST',
+            body: JSON.stringify(graphQLParams),
+            credentials: 'include',
+            headers: {
+              'content-type': 'application/json',
+              'x-csrf-token': token,
+              ...options.headers,
+              ...fetcherOpts.headers,
+            },
+          });
+          return data.json();
+        };
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: createSimpleFetcher({
+            url: '/graphql',
+          }),
+          defaultEditorToolsVisibility: true,
+        }),
+        document.getElementById('graphiql'),
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Description

Deploys: #318 

Note: This also re-enables csrf protection on the graphql endpoint. 
 
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
